### PR TITLE
Bad behavior when CSV file not found

### DIFF
--- a/hibike.py
+++ b/hibike.py
@@ -67,6 +67,7 @@ class Hibike():
         additional (key, value) pair of ("deviceName", deviceName)
         """
         try:
+            csv_file = None
             csv_file = open(contextFile, 'r')
             reader = csv.reader(csv_file, delimiter = ',', quotechar = '"', quoting = csv.QUOTE_MINIMAL)
             list_of_rows = [row for row in reader]
@@ -78,7 +79,8 @@ class Hibike():
         except IOError:
             return "ERROR: Hibike config filed does not exist."
         finally:
-            csv_file.close()
+            if csv_file is not None:
+                csv_file.close()
 
 
     def _enumerateSerialPorts(self):


### PR DESCRIPTION
When the csv file is not found, the `finally` clause still runs, except that the variable `csv_file` is unbound. This thrown an UnboundLocalException.

This is a temporary workaround.

Actual fix would:
- Not return a string to signal an error condition
- Not look in the local directory for the CSV file. (This means you can't import hibike from other folders). Easiest solution: use `os.path.join(__file__, 'hibikeDevices.csv')`
