### PR TITLE
New Team Flag implementation (full featured)

### DIFF
--- a/devices/TeamFlag/Makefile
+++ b/devices/TeamFlag/Makefile
@@ -1,0 +1,81 @@
+### DISCLAIMER
+### This is an example Makefile and it MUST be configured to suit your needs.
+### For detailled explanations about all the avalaible options,
+### please refer to https://github.com/sudar/Arduino-Makefile/blob/master/arduino-mk-vars.md
+
+### PROJECT_DIR
+### This is the path to where you have created/cloned your project
+
+PROJECT_DIR       = $(PWD)/../..
+
+### AVR_GCC_VERSION
+### Check if the version is equal or higher than 4.9
+AVR_GCC_VERSION  := $(shell expr `avr-gcc -dumpversion | cut -f1` \>= 4.9)
+
+### ARDMK_DIR
+### Path to the Arduino-Makefile directory.
+ARDMK_DIR         = $(PROJECT_DIR)/Arduino-Makefile
+
+### ARDUINO_DIR
+### Path to the Arduino application and ressources directory.
+ARDUINO_DIR       = /usr/share/arduino
+
+### USER_LIB_PATH
+### Path to where the your project's libraries are stored.
+SKETCH_LIBS = hibike
+USER_LIB_PATH     :=  $(realpath $(PROJECT_DIR)/lib)
+
+### BOARD_TAG & BOARD_SUB
+### For Arduino IDE 1.0.x
+### Only BOARD_TAG is needed. It must be set to the board you are currently using. (i.e uno, mega2560, etc.)
+# BOARD_TAG         = mega2560
+### For Arduino IDE 1.6.x
+### Both BOARD_TAG and BOARD_SUB are needed. They must be set to the board you are currently using. (i.e BOARD_TAG = uno, mega, etc. & BOARD_SUB = atmega2560, etc.)
+### Note: for the Arduino Uno, only BOARD_TAG is mandatory and BOARD_SUB can be equal to anything
+BOARD_TAG         = micro
+BOARD_SUB         = atmega32u4
+
+
+### MONITOR_BAUDRATE
+### It must be set to Serial baudrate value you are using.
+MONITOR_BAUDRATE  = 115200
+
+### AVR_TOOLS_DIR
+### Path to the AVR tools directory such as avr-gcc, avr-g++, etc.
+AVR_TOOLS_DIR     = /usr
+
+### AVRDDUDE
+### Path to avrdude directory.
+AVRDDUDE          = /usr/bin/avrdude
+
+### CFLAGS_STD
+CFLAGS_STD        = -std=gnu11
+
+### CXXFLAGS_STD
+CXXFLAGS_STD      = -std=gnu++11
+
+### CPPFLAGS
+### Flags you might want to set for debugging purpose. Comment to stop.
+CXXFLAGS         = -pedantic -Wall -Wextra
+
+### If avr-gcc -v is higher than 4.9, activate coloring of the output
+ifeq "$(AVR_GCC_VERSION)" "1"
+    CXXFLAGS += -fdiagnostics-color
+endif
+### random uid
+RANDOM := 0x$(shell head -c 8 /dev/urandom | xxd -p)
+CXXFLAGS += -D UID_RANDOM=$(RANDOM)
+### MONITOR_PORT
+### The port your board is connected to. Using an '*' tries all the ports and finds the right one.
+MONITOR_PORT      = /dev/ttyACM*
+
+### don't touch this
+CURRENT_DIR       = $(shell basename $(CURDIR))
+
+### OBJDIR
+### This is were you put the binaries you just compile using 'make'
+CURRENT_DIR       = $(shell basename $(CURDIR))
+OBJDIR            = $(PROJECT_DIR)/bin/$(CURRENT_DIR)/$(BOARD_TAG)
+
+### path to Arduino.mk, inside the ARDMK_DIR, don't touch.
+include $(ARDMK_DIR)/Arduino.mk

--- a/devices/TeamFlag/team_flag.cpp
+++ b/devices/TeamFlag/team_flag.cpp
@@ -1,0 +1,274 @@
+#include "team_flag.h"
+//////////////// DEVICE UID ///////////////////
+hibike_uid_t UID = {
+  TEAM_FLAG,                      // Device Type
+  0,                      // Year
+  UID_RANDOM,     // ID
+};
+///////////////////////////////////////////////
+
+message_t hibikeBuff;
+
+int params[NUM_PARAMS] = {0};
+
+uint64_t prevTime, currTime, heartbeat;
+uint8_t param;
+uint32_t value;
+uint16_t subDelay;
+const uint8_t pins[NUM_PINS] = {BLUE, YELLOW, STAT0, STAT1, STAT2, STAT3};
+bool led_enabled;
+uint64_t modePrevTime, modePeriod=1000;
+uint32_t temp;
+uint8_t temp8;
+
+void setup() {
+  Serial.begin(115200);
+  prevTime = millis();
+  subDelay = 0;
+
+
+  // Setup Error LED
+  pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, LOW);
+  led_enabled = false;
+
+  // Setup sensor input
+  for (int i = 0; i < NUM_PINS; i++) {
+    digitalWrite(pins[i], LOW);
+    pinMode(pins[i], OUTPUT);
+  }
+
+  // Inital param values
+  params[0] = TEAM_NONE;
+  params[1] = MODE_INITIAL;
+  for (int i=2; i<NUM_PARAMS; i++) {
+    params[i] = 0;
+  }
+  setupMode(params[1]);
+  modePrevTime = prevTime;
+
+  subDelay = 0;
+  heartbeat = 0;
+}
+
+
+void loop() {
+  // Read sensor
+  currTime = millis();
+
+  // Check for Hibike packets
+  if (Serial.available() > 1) {
+    if (read_message(&hibikeBuff) == -1) {
+      toggleLED();
+    } else {
+      switch (hibikeBuff.messageID) {
+        case SUBSCRIPTION_REQUEST:
+          // Unsupported packet
+          toggleLED();
+          break;
+
+        case SUBSCRIPTION_RESPONSE:
+          // Unsupported packet
+          toggleLED();
+          break;
+
+        case DATA_UPDATE:
+          // Unsupported packet
+          toggleLED();
+          break;
+
+        case DEVICE_UPDATE:
+          param = hibikeBuff.payload[0] - 1;
+          value = *((uint32_t*) &hibikeBuff.payload[DEVICE_PARAM_BYTES]);
+          if (param < NUM_PARAMS) {
+            deviceUpdate(param, value);
+            send_device_response(param+1, params[param]);
+          } else {
+            // Error due to too high a param index
+            toggleLED();
+          }
+          break;
+
+        case DEVICE_STATUS:
+          param = hibikeBuff.payload[0] - 1;
+          if (param < NUM_PARAMS) {
+            send_device_response(param+1, params[param]);
+          } else {
+            toggleLED();
+          }
+          break;
+
+        case DEVICE_RESPONSE:
+          // Unsupported packet
+          toggleLED();
+          break;
+        case PING_:
+          send_subscription_response(&UID, subDelay);
+          break;
+
+        default:
+          // Uh oh...
+          toggleLED();
+      }
+    }
+  }
+
+  if (currTime - heartbeat >= 1000) {
+    heartbeat = currTime;
+    toggleLED();
+  }
+  modeUpdateLeds(params[1]);
+}
+
+
+void deviceUpdate(uint8_t param, uint32_t value) {
+  /*enum {
+    MODE_INITIAL = 0,  // Initial mode, switches to direct as soon as any LED is set
+    MODE_DIRECT = 1,   // All LEDs controlled by the other parameters
+    MODE_DEMO = 2,     // Everything blinking quickly
+    MODE_ERROR = 3,    // Blink status LEDs quickly but leave team LEDs
+  };*/
+  //params[param] = value;
+  if (param == 0) {  // Setting the team param overrides the team LEDs (blue and yellow)
+    if (value == TEAM_BLUE) {
+      digitalWrite(YELLOW, LOW);
+      digitalWrite(BLUE, HIGH);
+      params[param] = value;
+      params[1] = MODE_DIRECT;
+      params[2] = 1;
+      params[3] = 0;
+    }else if (value == TEAM_YELLOW) {
+      digitalWrite(BLUE, LOW);
+      digitalWrite(YELLOW, HIGH);
+      params[param] = value;
+      params[1] = MODE_DIRECT;
+      params[2] = 0;
+      params[3] = 1;
+    }
+  }else if (param == 1) {  // Set the mode
+    if (value == MODE_INITIAL || value == MODE_DEMO || value == MODE_ERROR) {
+      params[param] = value;
+      setupMode(value);
+    }else {
+      params[param] = MODE_DIRECT;
+    }
+  }else {  // Directly set an LED
+    uint8_t ledPin = pins[(uint8_t)(param - 2)];
+    params[1] = MODE_DIRECT;
+    params[param] = setLed(ledPin, (uint16_t)value);
+  }
+
+  if (params[1] == MODE_DIRECT) {
+    for (int i=0; i<NUM_PINS; i++) {
+      setLed(pins[i], (uint16_t)params[i+2]);
+    }
+  }
+}
+uint16_t setLed(uint8_t pin, uint16_t value) {
+  if (value == 0) {  // If zero, turn off
+    value = 0;
+    digitalWrite(pin, LOW);
+    pinMode(pin, OUTPUT);
+  }else if (!(value & 0x8000)) {  // If positive, just turn on
+    value = 1;
+    digitalWrite(pin, HIGH);
+    pinMode(pin, OUTPUT);
+  }else {  // If negative, set the brightness between 0 and 255
+    value = -value;
+    if (value > 255) {
+      value = 255;
+    }
+    if (pin == BLUE || pin == YELLOW) {  // PWM enabled pins
+      analogWrite(pin, value);
+    } else {  // Hack half brightness using the input pullup pins
+      if (value < 64) {
+        digitalWrite(pin, LOW);
+        pinMode(pin, OUTPUT);
+      }else if (value < 128) {
+        pinMode(pin, INPUT);
+        digitalWrite(pin, HIGH);
+      }else {
+        pinMode(pin, OUTPUT);
+        digitalWrite(pin, HIGH);
+      }
+    }
+    return -value;
+  }
+  return value;
+}
+void setupMode(uint8_t mode) {
+  modePrevTime = millis();
+  switch (mode) {
+    case MODE_INITIAL:
+      modePeriod = 4000;
+      for (int i=0; i<2; i++) {
+        digitalWrite(pins[i], LOW);
+        pinMode(pins[i], OUTPUT);
+      }
+      for (int i=2; i<NUM_PINS; i++) {
+        pinMode(pins[i], INPUT);
+        digitalWrite(pins[i], HIGH);
+      }
+      return;
+    case MODE_DEMO:
+      modePeriod = 1000;
+      for (int i=0; i<NUM_PINS; i++) {
+        digitalWrite(pins[i], LOW);
+        pinMode(pins[i], OUTPUT);
+      }
+      return;
+    case MODE_ERROR:
+      modePeriod = 250;
+      for (int i=0; i<2; i++) {
+        setLed(pins[i], (uint16_t)params[i+2]);
+      }
+      for (int i=2; i<NUM_PINS; i++) {
+        pinMode(pins[i], OUTPUT);
+        digitalWrite(pins[i], HIGH);
+      }
+      return;
+    default: return;
+  }
+}
+void modeUpdateLeds(uint8_t mode) {
+  currTime = millis();
+  if (currTime - modePrevTime >= modePeriod) {
+    modePrevTime += modePeriod;
+  }
+  temp = (uint32_t)(currTime - modePrevTime);
+  switch (mode) {
+    case MODE_DIRECT: return;
+    case MODE_INITIAL:
+      temp8 = (uint8_t)(8*(pow(32, (temp >= 2000 ? (3999-temp) : temp)/2000.0)-1));
+      for (int i=0; i<2; i++) {
+        analogWrite(pins[i], temp8);
+      }
+      return;
+    case MODE_DEMO:
+      digitalWrite(BLUE, ((temp/500)&1));
+      digitalWrite(YELLOW, (((temp+250)/500)&1));
+      digitalWrite(STAT0, (((temp+125*0)/500)&1));
+      digitalWrite(STAT1, (((temp+125*1)/500)&1));
+      digitalWrite(STAT2, (((temp+125*2)/500)&1));
+      digitalWrite(STAT3, (((temp+125*3)/500)&1));
+      return;
+    case MODE_ERROR:
+      temp8 = temp >= 125 ? LOW : HIGH;
+      for (int i=2; i<NUM_PINS; i++) {
+        digitalWrite(pins[i], temp8);
+      }
+      return;
+  }
+}
+
+
+void toggleLED() {
+  if (led_enabled) {
+    digitalWrite(LED_PIN, LOW);
+    led_enabled = false;
+  } else {
+    digitalWrite(LED_PIN, HIGH);
+    led_enabled = true;
+  }
+  
+}

--- a/devices/TeamFlag/team_flag.h
+++ b/devices/TeamFlag/team_flag.h
@@ -1,0 +1,49 @@
+#ifndef EX_DEVICE_H
+#define EX_DEVICE_H
+
+#include "hibike_message.h"
+#include "devices.h"
+
+#define NUM_PARAMS 8
+
+#define NUM_PINS 6
+// Team LEDs
+#define BLUE 6    // PWM
+#define YELLOW 9  // PWM
+// Status LEDs
+#define STAT0 A0
+#define STAT1 A1
+#define STAT2 A2
+#define STAT3 A3
+
+#define LED_PIN 13
+
+enum {
+  MODE_INITIAL = 0,  // Initial mode
+  MODE_DIRECT = 1,   // All LEDs controlled by the other parameters
+  MODE_DEMO = 2,     // Everything blinking quickly
+  MODE_ERROR = 3,    // Blink status LEDs quickly but leave team LEDs
+};
+enum {
+  TEAM_BLUE = 0,
+  TEAM_YELLOW = 1,
+  TEAM_NONE = 255,
+};
+
+// function prototypes
+void setup();
+void loop();
+
+// Parameter Update 
+void update_param(uint8_t param, uint32_t value);
+
+// Device Update
+void deviceUpdate(uint8_t param, uint32_t value);
+uint16_t setLed(uint8_t pin, uint16_t value);
+void setupMode(uint8_t mode);
+void modeUpdateLeds(uint8_t mode);
+
+// functions to control this device
+void toggleLED();
+
+#endif /* EX_DEVICE_H */

--- a/hibikeDevices.csv
+++ b/hibikeDevices.csv
@@ -4,6 +4,6 @@ deviceID,deviceName,dataformat,scalingfactors,machinereadable,humanreadable,para
 0x02,Potentiometer,"<HHHH","1023,1023,1023,1023","value0,value1,value2,value3","Potentiometer 0,Potentiometer 1,Potentiometer 2,Potentiometer 3",dataUpdate,,,,
 0x03,Encoder,"<H","1","value0","Rotation",dataUpdate,,,,
 0x04,BatteryBuzzer,"<H??","1023,1,1","value0,value1,value2","Voltage, Safe, Connected",dataUpdate,,,,
-0x05,TeamFlag,"","","","",dataUpdate,blue,yellow,s1,s2,s3,s4
+0x05,TeamFlag,"","","","",dataUpdate,team,mode,blue,yellow,s1,s2,s3,s4
 0x07,ServoControl,"","","","",dataUpdate,servo0,servo1,servo2,servo3
 0xFFFF,ExampleDevice,"<?BHIQ","1,1,2,3,0.25","value0,value1,value2,value3,value4","Example 0,Example 1,Example 2,Example 3,Example 4",dataUpdate,test0,test1,test2,test3,test4,test5

--- a/lib/hibike/devices.h
+++ b/lib/hibike/devices.h
@@ -4,6 +4,7 @@
 typedef enum {
   LIMIT_SWITCH = 0x00,
   POTENTIOMETER = 0x02,
+  TEAM_FLAG = 0x05,
   SERVO_CONTROL = 0x07
 } deviceID;
 


### PR DESCRIPTION
For typical use, the 'team' parameter can be set to 0 or 1 for the Blue
or Yellow alliance and 's1' through 's4' to 0/1 for the status LEDs.

Brightness control and blinking modes are also supported.
